### PR TITLE
Make e-stop button work

### DIFF
--- a/client/src/components/dash-components/stop-button.tsx
+++ b/client/src/components/dash-components/stop-button.tsx
@@ -7,6 +7,7 @@ import {
 } from "@material-ui/core";
 import * as React from "react";
 import Button from "@material-ui/core/Button";
+import makeRequest from "../../utils/request/makeRequest";
 import { MuiThemeProvider } from "@material-ui/core/styles";
 import { red } from "@material-ui/core/colors";
 
@@ -29,7 +30,17 @@ class StopButton extends React.Component<StopProps> {
   }
 }
 function emergencyStop() {
-  alert("Initiating emergency stop");
+     const req = {"type":"estop","release":false};
+     makeRequest(
+         "/",
+         JSON.stringify(req),
+         () => {
+             alert("Sent e-stop command");
+         },
+         (error: string) => {
+             alert("Error sending e-stop command: " + error);
+         }
+     );
 }
 
 export default StopButton;

--- a/server/services/command.ts
+++ b/server/services/command.ts
@@ -23,8 +23,11 @@ const start = async function() {
 };
 
 function write(message) {
-  if (connection) connection.write(message);
-  else console.log("CANNOT WRITE TO ROVER, NO CONNECTION AVAILABLE");
+  if (connection) {
+    connection.write(message);
+  } else {
+    console.log("CANNOT WRITE TO ROVER, NO CONNECTION AVAILABLE");
+  }
 }
 
 export { connection, start, write };

--- a/server/services/server.ts
+++ b/server/services/server.ts
@@ -43,7 +43,7 @@ app.ws("/info", function(ws) {
 });
 
 app.post("/", function(req, res) {
-  commandService.write(JSON.stringify(req.body));
+  commandService.write(req.body);
   res.sendStatus(200);
 });
 


### PR DESCRIPTION
Fixes a bug where `makeRequest` body was getting redundantly re-stringified. Changes `emergencyStop` method to use `makeRequest`. Here's a video showing the e-stop button stopping the rover in simulation: https://huskyrobotics19-20.slack.com/files/USTU8J78C/F0199Q8EYUR/e-stop-rover.mp4 (requires PY2020 PR https://github.com/huskyroboticsteam/PY2020/pull/47 )