### PR TITLE
Gamepad controls

### DIFF
--- a/client/src/components/app.tsx
+++ b/client/src/components/app.tsx
@@ -16,6 +16,7 @@ import { MuiThemeProvider, createMuiTheme } from "@material-ui/core/styles";
 import "./app.css";
 import DataPacket from "../types";
 import 'mapbox-gl/dist/mapbox-gl.css';
+import ControllerComponent from './controller-component';
 
 const backTheme = createMuiTheme({
   palette: {
@@ -50,6 +51,7 @@ class App extends React.Component<AppProps> {
 
     return (
       <MuiThemeProvider theme={backTheme}>
+        <ControllerComponent />
         <HashRouter>
           <div style={{ top: "0" }}>
             <CssBaseline />

--- a/client/src/components/controller-component.tsx
+++ b/client/src/components/controller-component.tsx
@@ -1,32 +1,43 @@
 import * as React from "react";
 import Gamepad from "react-gamepad";
+import { RoverCommands } from "../rover-commands";
 
 type ControllerProps = {};
 
+let forwardBackward: number = 0.0;
+let leftRight: number = 0.0;
+
 class ControllerComponent extends React.Component<ControllerProps> {
+
   connectHandler(gamepadIndex: number) {
-    console.log(`Gamepad ${gamepadIndex} connected !`);
+    console.log(`Gamepad ${gamepadIndex} connected!`);
   }
 
   disconnectHandler(gamepadIndex: number) {
-    console.log(`Gamepad ${gamepadIndex} disconnected !`);
+    console.log(`Gamepad ${gamepadIndex} disconnected!`);
   }
 
   buttonChangeHandler(buttonName: string, down: boolean) {
-    console.log(buttonName, down);
+    // TODO
   }
 
   axisChangeHandler(axisName: string, value: number, previousValue: number) {
-    console.log(axisName, value);
+    if (axisName === "LeftStickY") {
+      forwardBackward = value;
+    } else if (axisName === "RightStickX") {
+      leftRight = value;
+    }
+    RoverCommands.setDrivePower(forwardBackward, leftRight);
   }
 
   buttonDownHandler(buttonName: string) {
-    console.log(buttonName, "down");
+    // TODO
   }
 
   buttonUpHandler(buttonName: string) {
-    console.log(buttonName, "up");
+    // TODO
   }
+
   render() {
     return (
       <Gamepad
@@ -35,7 +46,7 @@ class ControllerComponent extends React.Component<ControllerProps> {
         onButtonChange={this.buttonChangeHandler}
         onAxisChange={this.axisChangeHandler}
       >
-          <div></div>
+        <div></div>
       </Gamepad>
     );
   }

--- a/client/src/components/controller-component.tsx
+++ b/client/src/components/controller-component.tsx
@@ -4,8 +4,12 @@ import { RoverCommands } from "../rover-commands";
 
 type ControllerProps = {};
 
+// Current forward/backward input from gamepad
 let forwardBackward: number = 0.0;
+// Current left/right input from gamepad
 let leftRight: number = 0.0;
+// Used to ensure that gamepad input does not interfere with keyboard input
+let gamepadInUse: boolean = false;
 
 class ControllerComponent extends React.Component<ControllerProps> {
 
@@ -24,10 +28,22 @@ class ControllerComponent extends React.Component<ControllerProps> {
   axisChangeHandler(axisName: string, value: number, previousValue: number) {
     if (axisName === "LeftStickY") {
       forwardBackward = value;
+      if (value !== 0.0) {
+        gamepadInUse = true;
+      }
     } else if (axisName === "RightStickX") {
-      leftRight = value;
+      // negative leftRight causes clockwise rotation
+      leftRight = -value;
+      if (value != 0.0) {
+        gamepadInUse = true;
+      }
     }
-    RoverCommands.setDrivePower(forwardBackward, leftRight);
+    if (gamepadInUse) {
+      RoverCommands.setDrivePower(forwardBackward, leftRight);
+    }
+    if (forwardBackward === 0.0 && leftRight === 0.0) {
+      gamepadInUse = false;
+    }
   }
 
   buttonDownHandler(buttonName: string) {


### PR DESCRIPTION
Added support for using gamepads to drive rover around. I've only been able to test this with a USB Playstation controller so far. We'll need to come up with a control scheme for the arm if we want to use the gamepad for that too.