### PR TITLE
Add gamepad arm controls

### DIFF
--- a/client/src/arm-motor.ts
+++ b/client/src/arm-motor.ts
@@ -1,4 +1,7 @@
-export enum ArmMotor {
+/**
+ * Represents a type of arm motor on the rover.
+ */
+enum ArmMotor {
     ARM_BASE = "arm_base",
     SHOULDER = "shoulder",
     ELBOW = "elbow",
@@ -7,3 +10,5 @@ export enum ArmMotor {
     DIFF_RIGHT = "diffright",
     HAND = "hand"
 }
+
+export default ArmMotor;

--- a/client/src/components/app.tsx
+++ b/client/src/components/app.tsx
@@ -16,7 +16,7 @@ import { MuiThemeProvider, createMuiTheme } from "@material-ui/core/styles";
 import "./app.css";
 import DataPacket from "../types";
 import 'mapbox-gl/dist/mapbox-gl.css';
-import ControllerComponent from './controller-component';
+import GamepadComponent from './gamepad-component';
 
 const backTheme = createMuiTheme({
   palette: {
@@ -51,7 +51,7 @@ class App extends React.Component<AppProps> {
 
     return (
       <MuiThemeProvider theme={backTheme}>
-        <ControllerComponent />
+        <GamepadComponent />
         <HashRouter>
           <div style={{ top: "0" }}>
             <CssBaseline />

--- a/client/src/components/arm-components/motor-sensitivity-slider.tsx
+++ b/client/src/components/arm-components/motor-sensitivity-slider.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { setMotorSensitivity, update } from '../../keyboard-controls';
-import { ArmMotor } from '../../arm-motor';
+import ArmMotor from '../../arm-motor';
 
 interface MotorSensitivitySliderProps {
     motor: ArmMotor;

--- a/client/src/components/arm-components/motor-slider-list.tsx
+++ b/client/src/components/arm-components/motor-slider-list.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { ArmMotor } from "../../arm-motor";
+import ArmMotor from "../../arm-motor";
 import MotorSensitivitySlider from "./motor-sensitivity-slider";
 
 class MotorSliderList extends React.Component<{}, {}> {

--- a/client/src/components/controller-component.tsx
+++ b/client/src/components/controller-component.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import Gamepad from "react-gamepad";
-import { ArmMotor } from "../arm-motor";
-import { RoverCommands } from "../rover-commands";
+import ArmMotor from "../arm-motor";
+import RoverCommands from "../rover-commands";
 
 const DRIVER_GAMEPAD_INDEX = 0;
 const ARM_GAMEPAD_INDEX = 1;

--- a/client/src/components/dash-components/stop-status.tsx
+++ b/client/src/components/dash-components/stop-status.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { RoverCommands } from '../../rover-commands';
+import RoverCommands from '../../rover-commands';
 
 class StopStatus extends React.Component<{}, {}> {
-    
+
     render() {
         if (RoverCommands.isEStopped()) {
             return (

--- a/client/src/components/gamepad-component.tsx
+++ b/client/src/components/gamepad-component.tsx
@@ -9,7 +9,8 @@ const ARM_GAMEPAD_INDEX = 1;
 let forwardBackward = 0.0;
 let leftRight = 0.0;
 
-class ControllerComponent extends React.Component<{}, {}> {
+class GamepadComponent extends React.Component<{}, {}> {
+
   connectHandler(gamepadIndex: number) {
     if (gamepadIndex === DRIVER_GAMEPAD_INDEX) {
       console.log("Driver connected!");
@@ -92,6 +93,7 @@ class ControllerComponent extends React.Component<{}, {}> {
       </div>
     );
   }
+
 }
 
-export default ControllerComponent;
+export default GamepadComponent;

--- a/client/src/keyboard-controls.ts
+++ b/client/src/keyboard-controls.ts
@@ -21,9 +21,8 @@
  *  U/J: hand
  */
 
-import { ArmMotor } from "./arm-motor";
-import { RoverCommands } from "./rover-commands";
-
+import ArmMotor from "./arm-motor";
+import RoverCommands from "./rover-commands";
 
 /** Stores which keys are currently pressed. */
 const pressedKeys: Map<string, boolean> = new Map();

--- a/client/src/rover-commands.ts
+++ b/client/src/rover-commands.ts
@@ -41,7 +41,14 @@ class RoverCommands {
      * @param leftRight power in the horizontal direction [-1.0, 1.0]
      */
     static setDrivePower(forwardBackward: number, leftRight: number): void {
-        if (Math.abs(this.drivePower[0] - forwardBackward) >= EPSILON ||
+        if (this.drivePower[0] === forwardBackward && this.drivePower[1] === leftRight) {
+            // No need to update.
+            return;
+        }
+        // Only update if there is a significant difference or we want to cut
+        // off power completely.
+        if ((leftRight === 0 && forwardBackward === 0) ||
+            Math.abs(this.drivePower[0] - forwardBackward) >= EPSILON ||
             Math.abs(this.drivePower[1] - leftRight) >= EPSILON) {
             sendDriveCommand(forwardBackward, leftRight);
         }
@@ -64,6 +71,12 @@ class RoverCommands {
      * @param power the power [-1.0, 1.0]
      */
     static setMotorPower(motor: ArmMotor, power: number): void {
+        if (this.motorPower.get(motor) === power) {
+            // No need to update.
+            return;
+        }
+        // Only update if there is a significant difference or we want to cut
+        // off power completely.
         if (power === 0 || Math.abs(this.motorPower.get(motor) - power) >= EPSILON) {
             sendMotorCommand(motor, power);
         }

--- a/client/src/rover-commands.ts
+++ b/client/src/rover-commands.ts
@@ -1,5 +1,5 @@
 import React from "react";
-import { ArmMotor } from "./arm-motor";
+import ArmMotor from "./arm-motor";
 import StopStatus from "./components/dash-components/stop-status";
 import makeRequest from "./utils/request/makeRequest";
 
@@ -25,7 +25,7 @@ function initializeMotorPowerMap(): Map<ArmMotor, number> {
 /**
  * Class containing static methods for sending commands to the rover.
  */
-export class RoverCommands {
+class RoverCommands {
     private static drivePower: [number, number] = [0.0, 0.0];
     private static motorPower: Map<ArmMotor, number> = initializeMotorPowerMap();
     private static eStop: boolean = false;
@@ -193,3 +193,5 @@ function sendRequest(request: any): void {
 }
 
 setInterval(update, UPDATE_PERIOD_MILIS);
+
+export default RoverCommands;


### PR DESCRIPTION
Added gamepad controls for the arm as described in this image: 
![image](https://user-images.githubusercontent.com/43483846/126055270-3c99333f-23c5-40d4-afc6-4a077e5688c3.png)

I'll need someone else to test this since I don't have access to the physical rover. Some specific things to test for include making sure that the directions of motor movement actually match what's in the picture and that I didn't get the signs flipped.

To use the controls, simply plug two USB controllers into the computer running mission control. PS4, Xbox 360, Xbox One, and probably other controllers work.