### PR TITLE
Change op mode for arm back to PWM (instead of PID)

### DIFF
--- a/client/src/rover-commands.ts
+++ b/client/src/rover-commands.ts
@@ -140,7 +140,9 @@ function sendDriveCommand(forwardBackward: number, leftRight: number): void {
  * Sends motor-related command packets to the server.
  */
 function sendMotorCommand(motor: ArmMotor, power: number): void {
-    var op_mode_key = "incremental PID speed";
+    // Right now PID control doesn't work well on the rover.
+    //var op_mode_key = "incremental PID speed";
+    var op_mode_key = "PWM target";
     if (motor !== ArmMotor.ARM_BASE &&
         motor !== ArmMotor.SHOULDER &&
         motor !== ArmMotor.ELBOW) {


### PR DESCRIPTION
Right now PID control doesn't work well on the rover, so it's not a good
default. Hopefully at some point this summer I can debug the issues with
PID and we can switch this back.